### PR TITLE
Fixed the public functions bug

### DIFF
--- a/app/lib/controllers/json.php
+++ b/app/lib/controllers/json.php
@@ -42,17 +42,21 @@ class json extends \core\controller_model
     {
         $props = http::get_params();
         $wadl = new tadl();
-        $w = $wadl->get_tadl('exposed');
+        
         unset($props[0]);
         unset($props[1]);
         $namespace = "controllers"; //default namespace
         if (empty($props)) {
             // If it's just a /json call then we want to show all the callable functions.
             // Other wise it will show only the GET functions.
+            // since we list, we only want the exposed functions!
+            $w = $wadl->get_tadl('exposed');
             $protocol = "ALL";
             $controller = 'tadl';
             $method = 'show';
         } else {
+            // but if we have parameters, we want to be able to also access the public ones!
+        	$w = $wadl->get_tadl('public');
             $controller = array_shift($props) ?: 'tadl';
             $method = array_shift($props) ?: 'show';
         }


### PR DESCRIPTION
In previous versions of TADL, public functions were not listed (only the exposed ones were), but they could be run. In the new version, they were not listed nor run. This change fixes that.